### PR TITLE
ADD:画面遷移図のリンクを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,6 @@ README〜ER図作成：5/13 〆切
 - MySQL
 - React
 - Tailwind css
+
+画面遷移図
+https://www.figma.com/file/GZiXRQ5PUjq2hbmHWQhmK3/Nucleus-UI%3A-Mobile-App-UI-Component-Library-%E2%80%93-LITE-version-(Community)?type=design&node-id=858%3A8368&t=gX6C4TU1HHmrtNXU-1


### PR DESCRIPTION
画面遷移図のリンクをREADMEに追加しました。

https://www.figma.com/file/GZiXRQ5PUjq2hbmHWQhmK3/Nucleus-UI%3A-Mobile-App-UI-Component-Library-%E2%80%93-LITE-version-(Community)?type=design&node-id=858%3A8368&t=gX6C4TU1HHmrtNXU-1

■実装予定の機能
（以下の例は実際のアプリの機能から一部省略しています）

### 【すべてのユーザー】
#### LPに訪れたユーザーがどんなアプリか把握することができる
[x]３つの機能の閲覧ができる→LPで閲覧できる
  集める(collection)を閲覧できる
  ユーザーが投稿した飾る(decoration)を閲覧できる
  ユーザーの積み上げる(tower)を閲覧できる
#### 使用したユーザーが複数の動線から簡単に登録することができる
[x] 新規登録(認証ログイン)
  LPから登録できる
  閲覧ページの「使ってみる」ボタンから登録できる
  いいねボタンから登録できる→必要なさそうなので削除

### 【登録ユーザー】
[x]投稿機能(新規作成、編集、削除)使用することができる
  写真をアップロードし、コレクションに登録
  飾る、の新規作成、編集、削除
  積み上げるの新規作成

[x] 投稿をシェアすることができる

### メールアドレス・パスワード変更確認項目
googleログインのみの実装を予定

### 想定URL
特に違和感を感じなかった